### PR TITLE
File Check & Text Splicing

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -19,14 +19,13 @@ function activate(context) {
 	/* ---------------------------- */
 	const displayBackgroundImage = vscode.commands.registerCommand('chiya-theme.displayBackgroundImage', () => {
 		// Checks if there is a custom background image
-		if(fs.existsSync(`${paths.vscode.root}\\${paths.vscode.wrb}\\chiya-detector`)) {
+		const data = fs.readFileSync(`${paths.extension.root}\\${paths.extension.cbi}`, { encoding: "utf-8", flag: "r" });
+		if (fs.readFileSync(`${paths.vscode.root}\\${paths.vscode.wrb}\\${paths.vscode.wdm}`, { encoding: "utf-8", flag: "r" }).endsWith(data)) {
 			// Send Message
 			vscode.window.showWarningMessage("Custom background image already exists !");
 		} else {
 			// Edit VSCode CSS & Create a detector file
-			const data = fs.readFileSync(`${paths.extension.root}\\${paths.extension.cbi}`, { encoding: "utf-8", flag: "r" });
 			fs.writeFileSync(`${paths.vscode.root}\\${paths.vscode.wrb}\\${paths.vscode.wdm}`, data, { encoding: "utf-8", flag: "a" });
-			fs.openSync(`${paths.vscode.root}\\${paths.vscode.wrb}\\chiya-detector`, "w");
 
 			// Reload VSCode
 			vscode.commands.executeCommand("workbench.action.reloadWindow");
@@ -39,17 +38,16 @@ function activate(context) {
 
 
 
-	/* -------------------------- */
+	/* -------------------------- */	
 	/*  Hide the background image */
 	/* -------------------------- */
 	const hideBackgroundImage = vscode.commands.registerCommand('chiya-theme.hideBackgroundImage', () => {
 		// Checks if there is a custom background image
-		if(fs.existsSync(`${paths.vscode.root}\\${paths.vscode.wrb}\\chiya-detector`)) {
+		const dataLength = fs.readFileSync(`${paths.extension.root}\\${paths.extension.cbi}`, { encoding: "utf-8", flag: "r" }).length;
+		const data = fs.readFileSync(`${paths.vscode.root}\\${paths.vscode.wrb}\\${paths.vscode.wdm}`, { encoding: "utf-8", flag: "r" });
+		if (fs.readFileSync(`${paths.vscode.root}\\${paths.vscode.wrb}\\${paths.vscode.wdm}`, { encoding: "utf-8", flag: "r" }).endsWith(data)) {
 			// Edit VSCode CSS & Remove the detector file
-			const dataLength = fs.readFileSync(`${paths.extension.root}\\${paths.extension.cbi}`, { encoding: "utf-8", flag: "r" }).length;
-			const data = fs.readFileSync(`${paths.vscode.root}\\${paths.vscode.wrb}\\${paths.vscode.wdm}`, { encoding: "utf-8", flag: "r" });
 			fs.writeFileSync(`${paths.vscode.root}\\${paths.vscode.wrb}\\${paths.vscode.wdm}`, data.slice(0, -dataLength), { encoding: "utf-8"});
-			fs.unlinkSync(`${paths.vscode.root}\\${paths.vscode.wrb}\\chiya-detector`);
 
 			// Reload VSCode
 			vscode.commands.executeCommand("workbench.action.reloadWindow");


### PR DESCRIPTION
Had a problem with VSCode in correctly splicing the CSS when applying or removing the background image. Might make a more versatile method later, but for now this is what I've got.

Instead of checking for a file, I just check to see if the file `workbench.desktop.main.css` ends with the information grabbed from `data`. VS-Code also had some struggles checking for the file whilst I was working on this, so this works better.

I also noticed that when I accidentally uninstalled the plugin and reinstalled it, the background image which I didn't want enabled was still present. So with this method, in assumption that no other plugins are directly appending text to the end of `workbench.desktop.main.css`, after reinstallation of the plugin, you should still be able to remove the wallpaper without it struggling.

One of the main issues was that it would append the CSS to `workbench.desktop.main.css` and then if something failed during the check but it still appends the CSS, it would append the CSS underneath the already existing code whenever you tried to run the command, and running the command to remove it wouldn't remove anything, nullifying the wallpaper permanently and writing excess CSS to the `workbench.desktop.main.css` file.

This should also avoid any unnecessary memory being used up by creating and deleting files of *unknown* file-type(s).